### PR TITLE
Add view command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -339,7 +339,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     Steps 1b1-1b3 are repeated until the supplier is found. <br>
     Use case resumes from step 2.
 
-**Use case: UC04 clear all supplier and warehouse entries**
+**Use case: UC04 Clear all supplier and warehouse entries**
 
 **MSS**
 
@@ -442,6 +442,15 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Steps 1a1 and 1a2 are repeated until a valid find command is entered. <br>
     Use case resumes from step 2.
+
+**Use case: UC09 List all supplier and warehouse entries**
+
+**MSS**
+
+1. User requests to list the data in the application.
+2. CLI-nic retrieves all supplier and warehouse entries, shows lists of suppliers and warehouses and shows a success message.
+
+    Use case ends.
 
 **Use case: UC09 View Help**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -46,6 +46,8 @@ and efficient Graphical User Interface interaction.
    * **`find`** `PANADOL warehouse`** : Displays all the warehouses managed by the manager that has a product
     named PANADOL.
 
+  * **`list`** `list`** : Displays all the warehouses and suppliers in CLI-nic.
+
    * **`update`** `w/WarehouseA pd/Panadol q/10` : Updates the quantity of PANADOL in WarehouseA to 10. The
     quantity of PANADOL in WarehouseA can be more than 10 or lesser than 10 before the update is done.
 
@@ -156,6 +158,12 @@ Examples:
 * `find warehouse PANADOL SUSP` Displays all the warehouses managed by the manager that has a product named PANADOL SUSP.
 * `find supplier masks` Displays all the suppliers that have stock for the input product.
 
+### List all suppliers and warehouses entries : `list`
+
+List all entries (Suppliers and Warehouses) from the CLI-nic.
+
+Format: `list`
+
 ### View a specific supplier / warehouse: `view`
 
 Shows a particular supplier/warehouse with their relevant information e.g. products associated with the supplier/warehouse, address etc.
@@ -228,6 +236,7 @@ Action | Format, Examples
 **Clear** | `clear`
 **Delete** | `delete TYPE INDEX`<br> e.g., `delete 3`
 **Find** | `find TYPE KEYWORD…​`<br> e.g. `find warehouse panadol`
-**Help** | `help`
+**Help** | `help [COMMAND]`<br> e.g., `help add`
+**List** | `list`
 **Update** | `update w/WAREHOUSE_NAME pd/PRODUCT_NAME q/QUANTITY` <br> e.g., `update w/WarehouseA pd/Panadol q/10`
 **View** | `view TYPE NAME`<br> e.g. `view supplier supplierA`

--- a/src/main/java/seedu/clinic/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ListCommand.java
@@ -2,9 +2,9 @@ package seedu.clinic.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.clinic.model.Model.PREDICATE_SHOW_ALL_SUPPLIERS;
+import static seedu.clinic.model.Model.PREDICATE_SHOW_ALL_WAREHOUSES;
 
 import seedu.clinic.model.Model;
-import static seedu.clinic.model.Model.PREDICATE_SHOW_ALL_WAREHOUSES;
 
 /**
  * Lists all suppliers in the CLI-nic app to the user.
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all suppliers";
+    public static final String MESSAGE_SUCCESS = "Listed all suppliers and warehouses";
 
 
     @Override

--- a/src/main/java/seedu/clinic/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ListCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.clinic.model.Model.PREDICATE_SHOW_ALL_SUPPLIERS;
 
 import seedu.clinic.model.Model;
+import static seedu.clinic.model.Model.PREDICATE_SHOW_ALL_WAREHOUSES;
 
 /**
  * Lists all suppliers in the CLI-nic app to the user.
@@ -19,6 +20,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredSupplierList(PREDICATE_SHOW_ALL_SUPPLIERS);
+        model.updateFilteredWarehouseList(PREDICATE_SHOW_ALL_WAREHOUSES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
@@ -10,6 +10,12 @@ import seedu.clinic.model.Model;
 import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
 import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
 
+/**
+ * Display specific supplier(s) or warehouse(s) with name that matches any of keywords input by user.
+ * Keyword matching is case insensitive.
+ * Keyword only matches whole word e.g. bernice will match "bernice yeoh" but not "berniceyeoh".
+ * Keyword specified by user
+ */
 public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ":View information related to a"

--- a/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
@@ -1,14 +1,14 @@
 package seedu.clinic.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import seedu.clinic.commons.core.Messages;
 import seedu.clinic.logic.commands.exceptions.CommandException;
 import seedu.clinic.model.Model;
 import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
 import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
-
-import java.util.Collections;
-import java.util.List;
 
 public class ViewCommand extends Command {
     public static final String COMMAND_WORD = "view";
@@ -28,6 +28,12 @@ public class ViewCommand extends Command {
     private final String type;
     private final List<String> name;
 
+    /**
+     * Creates a new ViewCommand object.
+     *
+     * @param type takes in type of the viewCommand object, either supplier or warehouse.
+     * @param name takes in name(s) as keywords to find warehouse(s) or supplier(s).
+     */
     public ViewCommand(String type, List<String> name) {
         this.type = type;
         this.name = name;
@@ -53,5 +59,13 @@ public class ViewCommand extends Command {
                             model.getFilteredWarehouseList().size()));
         }
         return commandResult;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewCommand // instanceof handles nulls
+                && type.equals(((ViewCommand) other).type)
+                && name.equals(((ViewCommand) other).name));
     }
 }

--- a/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
@@ -1,0 +1,57 @@
+package seedu.clinic.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import seedu.clinic.commons.core.Messages;
+import seedu.clinic.logic.commands.exceptions.CommandException;
+import seedu.clinic.model.Model;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ViewCommand extends Command {
+    public static final String COMMAND_WORD = "view";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":View information related to a"
+            + " particular supplier or warehouse.\n"
+            + "Parameters:\nview TYPE NAME\n"
+            + "Example:\nview warehouse warehouseA\nview supplier supplierA\n";
+    public static final String MESSAGE_TOO_FEW_ARGUMENTS = "You should key in at least 2 arguments.\n"
+            + MESSAGE_USAGE;
+    public static final String MESSAGE_INVALID_TYPE = "Your type can only be supplier or warehouse.\n"
+            + MESSAGE_USAGE;
+    public static final int NUMBER_OF_ARGUMENTS = 2;
+    public static final int TYPE_IN_VIEW_COMMAND = 0;
+    public static final int NAME_IN_VIEW_COMMAND = 1;
+    public static final String[] ALLOWED_TYPES = new String[]{"supplier", "warehouse"};
+
+    private final String type;
+    private final List<String> name;
+
+    public ViewCommand(String type, List<String> name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        CommandResult commandResult;
+        if (type.equals("supplier")) {
+            NameContainsKeywordsPredicateForSupplier supplierPredicate =
+                    new NameContainsKeywordsPredicateForSupplier(name);
+            model.updateFilteredSupplierList(supplierPredicate);
+            commandResult = new CommandResult(
+                    String.format(Messages.MESSAGE_SUPPLIERS_LISTED_OVERVIEW,
+                            model.getFilteredSupplierList().size()));
+        } else {
+            NameContainsKeywordsPredicateForWarehouse warehousePredicate =
+                    new NameContainsKeywordsPredicateForWarehouse(name);
+            model.updateFilteredWarehouseList(warehousePredicate);
+            commandResult = new CommandResult(
+                    String.format(Messages.MESSAGE_WAREHOUSE_LISTED_OVERVIEW,
+                            model.getFilteredWarehouseList().size()));
+        }
+        return commandResult;
+    }
+}

--- a/src/main/java/seedu/clinic/logic/parser/ClinicParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/ClinicParser.java
@@ -15,6 +15,7 @@ import seedu.clinic.logic.commands.ExitCommand;
 import seedu.clinic.logic.commands.FindCommand;
 import seedu.clinic.logic.commands.HelpCommand;
 import seedu.clinic.logic.commands.ListCommand;
+import seedu.clinic.logic.commands.ViewCommand;
 import seedu.clinic.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class ClinicParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/clinic/logic/parser/ClinicParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/ClinicParser.java
@@ -15,8 +15,8 @@ import seedu.clinic.logic.commands.ExitCommand;
 import seedu.clinic.logic.commands.FindCommand;
 import seedu.clinic.logic.commands.HelpCommand;
 import seedu.clinic.logic.commands.ListCommand;
-import seedu.clinic.logic.commands.ViewCommand;
 import seedu.clinic.logic.commands.UpdateCommand;
+import seedu.clinic.logic.commands.ViewCommand;
 import seedu.clinic.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/clinic/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/ViewCommandParser.java
@@ -1,0 +1,42 @@
+package seedu.clinic.logic.parser;
+
+import static seedu.clinic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.clinic.logic.commands.ViewCommand;
+import static seedu.clinic.logic.commands.ViewCommand.ALLOWED_TYPES;
+import static seedu.clinic.logic.commands.ViewCommand.NAME_IN_VIEW_COMMAND;
+import static seedu.clinic.logic.commands.ViewCommand.NUMBER_OF_ARGUMENTS;
+import static seedu.clinic.logic.commands.ViewCommand.TYPE_IN_VIEW_COMMAND;
+import seedu.clinic.logic.parser.exceptions.ParseException;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ViewCommandParser implements Parser<ViewCommand> {
+
+    @Override
+    public ViewCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        }
+
+        String[] userInputs = trimmedArgs.split("\\s+");
+        if (userInputs.length < NUMBER_OF_ARGUMENTS) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        }
+
+        String type = userInputs[TYPE_IN_VIEW_COMMAND].toLowerCase();
+        List<String> name = Arrays.asList(userInputs).subList(NAME_IN_VIEW_COMMAND, userInputs.length);
+
+        if (!Arrays.asList(ALLOWED_TYPES).contains(type.toLowerCase())) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        }
+
+        return new ViewCommand(type, name);
+    }
+}

--- a/src/main/java/seedu/clinic/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/ViewCommandParser.java
@@ -1,17 +1,16 @@
 package seedu.clinic.logic.parser;
 
 import static seedu.clinic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import seedu.clinic.logic.commands.ViewCommand;
 import static seedu.clinic.logic.commands.ViewCommand.ALLOWED_TYPES;
 import static seedu.clinic.logic.commands.ViewCommand.NAME_IN_VIEW_COMMAND;
 import static seedu.clinic.logic.commands.ViewCommand.NUMBER_OF_ARGUMENTS;
 import static seedu.clinic.logic.commands.ViewCommand.TYPE_IN_VIEW_COMMAND;
-import seedu.clinic.logic.parser.exceptions.ParseException;
-import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
-import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
 
 import java.util.Arrays;
 import java.util.List;
+
+import seedu.clinic.logic.commands.ViewCommand;
+import seedu.clinic.logic.parser.exceptions.ParseException;
 
 public class ViewCommandParser implements Parser<ViewCommand> {
 

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>

--- a/src/test/data/JsonSerializableClinicTest/typicalSuppliersClinic.json
+++ b/src/test/data/JsonSerializableClinicTest/typicalSuppliersClinic.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Clinic save file which contains the same supplier values as in TypicalSuppliers#getTypicalClinic()",
+  "_comment": "Clinic save file which contains the same supplier values as in TypicalSuppliers#getTypicalSupplierOnlyClinic()",
   "suppliers" : [ {
     "name" : "Alice Pauline Ltd",
     "phone" : "94351253",

--- a/src/test/data/JsonSerializableClinicTest/typicalWarehousesClinic.json
+++ b/src/test/data/JsonSerializableClinicTest/typicalWarehousesClinic.json
@@ -2,7 +2,7 @@
   "_comment": "Clinic save file which contains the same supplier values as in TypicalSuppliers#getTypicalAddressBook()",
   "suppliers" : [ ],
   "warehouses": [ {
-    "name" : "Warehouse Alice",
+    "name" : "Alice Warehouse",
     "phone" : "94351253",
     "address" : "alice address",
     "remark" : "Warehouse 1",

--- a/src/test/data/JsonSerializableClinicTest/typicalWarehousesClinic.json
+++ b/src/test/data/JsonSerializableClinicTest/typicalWarehousesClinic.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Clinic save file which contains the same supplier values as in TypicalSuppliers#getTypicalAddressBook()",
+  "_comment": "Clinic save file which contains the same supplier values as in TypicalWarehouses#getTypicalWarehouseOnlyClinic()",
   "suppliers" : [ ],
   "warehouses": [ {
     "name" : "Alice Warehouse",

--- a/src/test/java/seedu/clinic/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/clinic/logic/commands/CommandTestUtil.java
@@ -179,11 +179,9 @@ public class CommandTestUtil {
      */
     public static void showWarehouseAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredWarehouseList().size());
-
         Warehouse warehouse = model.getFilteredWarehouseList().get(targetIndex.getZeroBased());
         final String[] splitName = warehouse.getName().fullName.split("\\s+");
         model.updateFilteredWarehouseList(new NameContainsKeywordsPredicateForWarehouse(Arrays.asList(splitName[0])));
-
         assertEquals(1, model.getFilteredWarehouseList().size());
     }
 }

--- a/src/test/java/seedu/clinic/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/ListCommandTest.java
@@ -34,13 +34,13 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_listIsFilteredSupplier_showsEverythingWarehouseShowOneSupplier() {
+    public void execute_listIsFilteredSupplier_showsAllWarehouseShowsOneSupplier() {
         showSupplierAtIndex(model, INDEX_FIRST_SUPPLIER);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
-    public void execute_listIsFilteredWarehouse_showsEverythingSupplierShowOneWarehouse() {
+    public void execute_listIsFilteredWarehouse_showsAllSupplierShowsOneWarehouse() {
         showWarehouseAtIndex(model, INDEX_FIRST_WAREHOUSE);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/clinic/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/ListCommandTest.java
@@ -2,7 +2,9 @@ package seedu.clinic.logic.commands;
 
 import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinic.logic.commands.CommandTestUtil.showSupplierAtIndex;
+import static seedu.clinic.logic.commands.CommandTestUtil.showWarehouseAtIndex;
 import static seedu.clinic.testutil.TypicalIndexes.INDEX_FIRST_SUPPLIER;
+import static seedu.clinic.testutil.TypicalIndexes.INDEX_FIRST_WAREHOUSE;
 import static seedu.clinic.testutil.TypicalSupplier.getTypicalClinic;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,8 +34,14 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_listIsFiltered_showsEverything() {
+    public void execute_listIsFilteredSupplier_showsEverythingWarehouseShowOneSupplier() {
         showSupplierAtIndex(model, INDEX_FIRST_SUPPLIER);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFilteredWarehouse_showsEverythingSupplierShowOneWarehouse() {
+        showWarehouseAtIndex(model, INDEX_FIRST_WAREHOUSE);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/clinic/logic/commands/ViewSuppliersCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/ViewSuppliersCommandTest.java
@@ -1,0 +1,81 @@
+package seedu.clinic.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinic.testutil.TypicalSupplier.getTypicalClinic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinic.commons.core.Messages;
+import seedu.clinic.model.Model;
+import seedu.clinic.model.ModelManager;
+import seedu.clinic.model.UserPrefs;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForSupplier;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code ViewCommand}.
+ */
+public class ViewSuppliersCommandTest {
+    private final String type = "supplier";
+
+    private Model model = new ModelManager(getTypicalClinic(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalClinic(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        List<String> firstName = new ArrayList<>();
+        firstName.add("first supplier");
+        List<String> secondName = new ArrayList<>();
+        secondName.add("second supplier");
+
+        ViewCommand viewFirstCommand = new ViewCommand(type, firstName);
+        ViewCommand viewSecondCommand = new ViewCommand(type, secondName);
+
+        // same object -> returns true
+        assertTrue(viewFirstCommand.equals(viewFirstCommand));
+
+        // same values -> returns true
+        ViewCommand viewFirstCommandCopy = new ViewCommand(type, firstName);
+        assertTrue(viewFirstCommand.equals(viewFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewFirstCommand.equals(null));
+
+        // different supplier -> returns false
+        assertFalse(viewFirstCommand.equals(viewSecondCommand));
+    }
+
+    @Test
+    public void execute_oneWordInName_success() {
+        String supplierName = "Fiona";
+        String expectedMessage = String.format(Messages.MESSAGE_SUPPLIERS_LISTED_OVERVIEW, 1);
+        ViewCommand viewFirstCommand = new ViewCommand(type, Arrays.asList(supplierName));
+        NameContainsKeywordsPredicateForSupplier supplierPredicate =
+                new NameContainsKeywordsPredicateForSupplier(Arrays.asList(supplierName));
+        model.updateFilteredSupplierList(supplierPredicate);
+        expectedModel.updateFilteredSupplierList(supplierPredicate);
+        assertCommandSuccess(viewFirstCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleWordInName_success() {
+        String supplierName = "Fiona DANIEL";
+        String[] supplierNames = supplierName.trim().split("\\s+");
+        String expectedMessage = String.format(Messages.MESSAGE_SUPPLIERS_LISTED_OVERVIEW, 2);
+        ViewCommand viewFirstCommand = new ViewCommand(type, Arrays.asList(supplierNames));
+        NameContainsKeywordsPredicateForSupplier supplierPredicate =
+                new NameContainsKeywordsPredicateForSupplier(Arrays.asList(supplierNames));
+        model.updateFilteredSupplierList(supplierPredicate);
+        expectedModel.updateFilteredSupplierList(supplierPredicate);
+        assertCommandSuccess(viewFirstCommand, model, expectedMessage, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/clinic/logic/commands/ViewWarehousesCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/ViewWarehousesCommandTest.java
@@ -1,0 +1,77 @@
+package seedu.clinic.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.clinic.testutil.TypicalSupplier.getTypicalClinic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinic.commons.core.Messages;
+import seedu.clinic.model.Model;
+import seedu.clinic.model.ModelManager;
+import seedu.clinic.model.UserPrefs;
+import seedu.clinic.model.attribute.NameContainsKeywordsPredicateForWarehouse;
+
+public class ViewWarehousesCommandTest {
+    private final String type = "warehouse";
+
+    private Model model = new ModelManager(getTypicalClinic(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalClinic(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        List<String> firstName = new ArrayList<>();
+        firstName.add("first warehouse");
+        List<String> secondName = new ArrayList<>();
+        secondName.add("second warehouse");
+
+        ViewCommand viewFirstCommand = new ViewCommand(type, firstName);
+        ViewCommand viewSecondCommand = new ViewCommand(type, secondName);
+
+        // same object -> returns true
+        assertTrue(viewFirstCommand.equals(viewFirstCommand));
+
+        // same values -> returns true
+        ViewCommand viewFirstCommandCopy = new ViewCommand(type, firstName);
+        assertTrue(viewFirstCommand.equals(viewFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewFirstCommand.equals(null));
+
+        // different supplier -> returns false
+        assertFalse(viewFirstCommand.equals(viewSecondCommand));
+    }
+
+    @Test
+    public void execute_oneWordInName_success() {
+        String warehouseName = "Fiona";
+        String expectedMessage = String.format(Messages.MESSAGE_WAREHOUSE_LISTED_OVERVIEW, 1);
+        ViewCommand viewFirstCommand = new ViewCommand(type, Arrays.asList(warehouseName));
+        NameContainsKeywordsPredicateForWarehouse warehousePredicate =
+                new NameContainsKeywordsPredicateForWarehouse(Arrays.asList(warehouseName));
+        model.updateFilteredWarehouseList(warehousePredicate);
+        expectedModel.updateFilteredWarehouseList(warehousePredicate);
+        assertCommandSuccess(viewFirstCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleWordInName_success() {
+        String warehouseName = "Fiona DANIEL";
+        String[] warehouseNames = warehouseName.trim().split("\\s+");
+        String expectedMessage = String.format(Messages.MESSAGE_WAREHOUSE_LISTED_OVERVIEW, 2);
+        ViewCommand viewFirstCommand = new ViewCommand(type, Arrays.asList(warehouseNames));
+        NameContainsKeywordsPredicateForWarehouse warehousePredicate =
+                new NameContainsKeywordsPredicateForWarehouse(Arrays.asList(warehouseNames));
+        model.updateFilteredWarehouseList(warehousePredicate);
+        expectedModel.updateFilteredWarehouseList(warehousePredicate);
+        assertCommandSuccess(viewFirstCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/clinic/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/ViewCommandParserTest.java
@@ -1,0 +1,95 @@
+package seedu.clinic.logic.parser;
+
+import static seedu.clinic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.clinic.logic.commands.ViewCommand;
+
+public class ViewCommandParserTest {
+
+    private final Parser parser = new ViewCommandParser();
+
+    @Test
+    public void parse_zeroKeywords_throwParsesException() {
+        assertParseFailure(parser, "", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_onlyTypeNoKeywords_throwParsesException() {
+        assertParseFailure(parser, "supplier ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        assertParseFailure(parser, "suPPLIEr ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        assertParseFailure(parser, "WAREHOUSE ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        assertParseFailure(parser, "WAREhouse ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        assertParseFailure(parser, "warehouse ", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+    }
+
+    @Test
+    public void parse_onlyOneKeywordNoType_throwParsesException() {
+        assertParseFailure(parser, "alice", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+        assertParseFailure(parser, "bENson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_TOO_FEW_ARGUMENTS));
+    }
+
+    @Test
+    public void parse_onlyMultipleKeywordsNoType_throwParsesException() {
+        assertParseFailure(parser, "alice benson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        assertParseFailure(parser, "ALIce bENson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+    }
+
+    @Test
+    public void parse_wrongTypeCorrectMultipleKeyWords_throwParsesException() {
+        assertParseFailure(parser, "VIEWWArehouse alice benson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        assertParseFailure(parser, "VIEWSupplier ALIce bENson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        assertParseFailure(parser, "See ALIce bENson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+    }
+
+    @Test
+    public void parse_wrongTypeCorrectOneKeyWord_throwParsesException() {
+        assertParseFailure(parser, "VIEWWArehouse alice", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        assertParseFailure(parser, "VIEWSupplier bENson", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+        assertParseFailure(parser, "See ALIce", String.format(
+                MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_INVALID_TYPE));
+    }
+
+    @Test
+    public void parse_correctTypeCorrectKeyWords_success() {
+        ViewCommand expectedViewCommand1 = new ViewCommand("supplier", Arrays.asList(new String[]
+            {"alice", "benson"}));
+        assertParseSuccess(parser, "supplier alice benson", expectedViewCommand1);
+
+        ViewCommand expectedViewCommand2 = new ViewCommand("supplier", Arrays.asList(new String[]
+            {"ALIce", "bENson"}));
+        assertParseSuccess(parser, "Supplier ALIce bENson", expectedViewCommand2);
+
+        ViewCommand expectedViewCommand3 = new ViewCommand("warehouse", Arrays.asList(new String[]
+            {"ALIce", "bENson"}));
+        assertParseSuccess(parser, "warehouse ALIce bENson", expectedViewCommand3);
+
+        ViewCommand expectedViewCommand4 = new ViewCommand("warehouse", Arrays.asList(new String[]
+            {"alice", "benson"}));
+        assertParseSuccess(parser, "wArehouse alice benson", expectedViewCommand4);
+    }
+
+
+}

--- a/src/test/java/seedu/clinic/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/ViewCommandParserTest.java
@@ -4,7 +4,7 @@ import static seedu.clinic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -74,20 +74,16 @@ public class ViewCommandParserTest {
 
     @Test
     public void parse_correctTypeCorrectKeyWords_success() {
-        ViewCommand expectedViewCommand1 = new ViewCommand("supplier", Arrays.asList(new String[]
-            {"alice", "benson"}));
+        ViewCommand expectedViewCommand1 = new ViewCommand("supplier", List.of("alice", "benson"));
         assertParseSuccess(parser, "supplier alice benson", expectedViewCommand1);
 
-        ViewCommand expectedViewCommand2 = new ViewCommand("supplier", Arrays.asList(new String[]
-            {"ALIce", "bENson"}));
+        ViewCommand expectedViewCommand2 = new ViewCommand("supplier", List.of("ALIce", "bENson"));
         assertParseSuccess(parser, "Supplier ALIce bENson", expectedViewCommand2);
 
-        ViewCommand expectedViewCommand3 = new ViewCommand("warehouse", Arrays.asList(new String[]
-            {"ALIce", "bENson"}));
+        ViewCommand expectedViewCommand3 = new ViewCommand("warehouse", List.of("ALIce", "bENson"));
         assertParseSuccess(parser, "warehouse ALIce bENson", expectedViewCommand3);
 
-        ViewCommand expectedViewCommand4 = new ViewCommand("warehouse", Arrays.asList(new String[]
-            {"alice", "benson"}));
+        ViewCommand expectedViewCommand4 = new ViewCommand("warehouse", List.of("alice", "benson"));
         assertParseSuccess(parser, "wArehouse alice benson", expectedViewCommand4);
     }
 

--- a/src/test/java/seedu/clinic/storage/JsonSerializableClinicTest.java
+++ b/src/test/java/seedu/clinic/storage/JsonSerializableClinicTest.java
@@ -2,6 +2,7 @@ package seedu.clinic.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.clinic.testutil.Assert.assertThrows;
+import static seedu.clinic.testutil.TypicalSupplier.getTypicalSupplierOnlyClinic;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import seedu.clinic.commons.exceptions.IllegalValueException;
 import seedu.clinic.commons.util.JsonUtil;
 import seedu.clinic.model.Clinic;
-import seedu.clinic.testutil.TypicalSupplier;
 import seedu.clinic.testutil.TypicalWarehouse;
 
 public class JsonSerializableClinicTest {
@@ -29,7 +29,7 @@ public class JsonSerializableClinicTest {
         JsonSerializableClinic dataFromFile = JsonUtil.readJsonFile(TYPICAL_SUPPLIERS_FILE,
                 JsonSerializableClinic.class).get();
         Clinic clinicFromFile = dataFromFile.toModelType();
-        Clinic typicalSuppliersClinic = TypicalSupplier.getTypicalClinic();
+        Clinic typicalSuppliersClinic = getTypicalSupplierOnlyClinic();
         assertEquals(clinicFromFile, typicalSuppliersClinic);
     }
 

--- a/src/test/java/seedu/clinic/testutil/TypicalSupplier.java
+++ b/src/test/java/seedu/clinic/testutil/TypicalSupplier.java
@@ -77,25 +77,25 @@ public class TypicalSupplier {
      * Returns an {@code Clinic} with all the typical suppliers and warehouses.
      */
     public static Clinic getTypicalClinic() {
-        Clinic ab = new Clinic();
+        Clinic clinic = new Clinic();
         for (Supplier supplier : getTypicalSuppliers()) {
-            ab.addSupplier(supplier);
+            clinic.addSupplier(supplier);
         }
         for (Warehouse warehouse : TypicalWarehouse.getTypicalWarehouses()) {
-            ab.addWarehouse(warehouse);
+            clinic.addWarehouse(warehouse);
         }
-        return ab;
+        return clinic;
     }
 
     /**
      * Returns an {@code Clinic} with all the typical suppliers.
      */
     public static Clinic getTypicalSupplierOnlyClinic() {
-        Clinic ab = new Clinic();
+        Clinic clinic = new Clinic();
         for (Supplier supplier : getTypicalSuppliers()) {
-            ab.addSupplier(supplier);
+            clinic.addSupplier(supplier);
         }
-        return ab;
+        return clinic;
     }
 
     public static List<Supplier> getTypicalSuppliers() {

--- a/src/test/java/seedu/clinic/testutil/TypicalSupplier.java
+++ b/src/test/java/seedu/clinic/testutil/TypicalSupplier.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import seedu.clinic.model.Clinic;
 import seedu.clinic.model.supplier.Supplier;
+import seedu.clinic.model.warehouse.Warehouse;
 
 /**
  * A utility class containing a list of {@code Supplier} objects to be used in tests.
@@ -79,6 +80,9 @@ public class TypicalSupplier {
         Clinic ab = new Clinic();
         for (Supplier supplier : getTypicalSuppliers()) {
             ab.addSupplier(supplier);
+        }
+        for (Warehouse warehouse : TypicalWarehouse.getTypicalWarehouses()) {
+            ab.addWarehouse(warehouse);
         }
         return ab;
     }

--- a/src/test/java/seedu/clinic/testutil/TypicalWarehouse.java
+++ b/src/test/java/seedu/clinic/testutil/TypicalWarehouse.java
@@ -26,7 +26,7 @@ import seedu.clinic.model.warehouse.Warehouse;
  */
 public class TypicalWarehouse {
 
-    public static final Warehouse ALICE = new WarehouseBuilder().withName("Warehouse Alice")
+    public static final Warehouse ALICE = new WarehouseBuilder().withName("Alice Warehouse")
             .withRemark("Warehouse 1").withAddress("alice address")
             .withPhone("94351253")
             .withProducts(Map.of("Panadol", 100)).build();

--- a/src/test/java/seedu/clinic/testutil/TypicalWarehouse.java
+++ b/src/test/java/seedu/clinic/testutil/TypicalWarehouse.java
@@ -86,11 +86,11 @@ public class TypicalWarehouse {
      * Returns an {@code Clinic} with all the typical warehouses.
      */
     public static Clinic getTypicalWarehouseOnlyClinic() {
-        Clinic ab = new Clinic();
+        Clinic clinic = new Clinic();
         for (Warehouse warehouse : getTypicalWarehouses()) {
-            ab.addWarehouse(warehouse);
+            clinic.addWarehouse(warehouse);
         }
-        return ab;
+        return clinic;
     }
 
     public static List<Warehouse> getTypicalWarehouses() {


### PR DESCRIPTION
View Command has been implemented, and list command as been edited. 
Also amended the first entry of json file/typical warehouses since a match by first word of name in list test would result in finding for the word (warehouse), which would cause all 7 entries to be found by the predicate function.

Edited User Guide to include list command, have also updated the developer guide for list command's use case.