### PR TITLE
Increase test coverage

### DIFF
--- a/src/main/java/seedu/clinic/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/AddCommandParser.java
@@ -64,11 +64,6 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Type type = ParserUtil.parseType(argMultimap.getValue(PREFIX_TYPE).get());
 
-        if (!type.equals(SUPPLIER) && !type.equals(WAREHOUSE)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_TYPE,
-                    AddCommand.MESSAGE_USAGE));
-        }
-
         if (type.equals(SUPPLIER)) {
             logger.log(Level.INFO, "User input contains type prefix for supplier.");
 

--- a/src/main/java/seedu/clinic/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/clinic/logic/parser/AddCommandParser.java
@@ -10,7 +10,6 @@ import static seedu.clinic.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.clinic.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.clinic.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.clinic.logic.parser.CliSyntax.PREFIX_TYPE;
-import static seedu.clinic.logic.parser.ParserUtil.MESSAGE_INVALID_TYPE;
 import static seedu.clinic.logic.parser.Type.SUPPLIER;
 import static seedu.clinic.logic.parser.Type.WAREHOUSE;
 

--- a/src/test/java/seedu/clinic/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/clinic/logic/commands/CommandTestUtil.java
@@ -53,6 +53,7 @@ public class CommandTestUtil {
     public static final String VALID_WAREHOUSE_PRODUCT_NAME_B = "Aspirin";
     public static final int VALID_WAREHOUSE_PRODUCT_QUANTITY_A = 10;
     public static final int VALID_WAREHOUSE_PRODUCT_QUANTITY_B = 20;
+    public static final int VALID_WAREHOUSE_PRODUCT_QUANTITY_50 = 50;
     public static final String VALID_WAREHOUSE_PRODUCT_TAG_FEVER = "fever";
     public static final String VALID_WAREHOUSE_PRODUCT_TAG_HEADACHE = "headache";
 

--- a/src/test/java/seedu/clinic/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/EditCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.clinic.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.clinic.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_NAME_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinic.logic.commands.CommandTestUtil.showSupplierAtIndex;
@@ -119,10 +120,12 @@ public class EditCommandTest {
 
         WarehouseBuilder warehouseInList = new WarehouseBuilder(lastWarehouse);
         Warehouse editedWarehouse = warehouseInList.withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).build();
+                .withPhone(VALID_PHONE_BOB)
+                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, 50)).build();
 
         EditWarehouseDescriptor descriptorWarehouse = new EditWarehouseDescriptorBuilder()
-                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB).build();
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, 50)).build();
         EditCommand editCommandWarehouse = new EditCommand(indexLastWarehouse, descriptorWarehouse);
 
         String expectedMessageWarehouse = String.format(EditCommand.MESSAGE_EDIT_WAREHOUSE_SUCCESS,

--- a/src/test/java/seedu/clinic/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/clinic/logic/commands/EditCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.clinic.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_NAME_A;
+import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_QUANTITY_50;
 import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.clinic.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.clinic.logic.commands.CommandTestUtil.showSupplierAtIndex;
@@ -121,11 +122,11 @@ public class EditCommandTest {
         WarehouseBuilder warehouseInList = new WarehouseBuilder(lastWarehouse);
         Warehouse editedWarehouse = warehouseInList.withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB)
-                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, 50)).build();
+                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, VALID_WAREHOUSE_PRODUCT_QUANTITY_50)).build();
 
         EditWarehouseDescriptor descriptorWarehouse = new EditWarehouseDescriptorBuilder()
                 .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, 50)).build();
+                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, VALID_WAREHOUSE_PRODUCT_QUANTITY_50)).build();
         EditCommand editCommandWarehouse = new EditCommand(indexLastWarehouse, descriptorWarehouse);
 
         String expectedMessageWarehouse = String.format(EditCommand.MESSAGE_EDIT_WAREHOUSE_SUCCESS,

--- a/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.clinic.logic.parser;
 
+import static seedu.clinic.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.clinic.logic.commands.CommandTestUtil.ADDRESS_DESC_WAREHOUSE_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.ADDRESS_DESC_WAREHOUSE_B;
 import static seedu.clinic.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -10,6 +11,7 @@ import static seedu.clinic.logic.commands.CommandTestUtil.INVALID_NAME_DESC2;
 import static seedu.clinic.logic.commands.CommandTestUtil.INVALID_NAME_DESC_WAREHOUSE2;
 import static seedu.clinic.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.clinic.logic.commands.CommandTestUtil.INVALID_REMARK_DESC;
+import static seedu.clinic.logic.commands.CommandTestUtil.INVALID_TYPE_DESC;
 import static seedu.clinic.logic.commands.CommandTestUtil.NAME_DESC_AMY2;
 import static seedu.clinic.logic.commands.CommandTestUtil.NAME_DESC_BOB2;
 import static seedu.clinic.logic.commands.CommandTestUtil.NAME_DESC_WAREHOUSE_A2;
@@ -37,8 +39,10 @@ import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_ADDRES
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_NAME_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PHONE_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_REMARK_A;
+import static seedu.clinic.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.clinic.logic.parser.ParserUtil.MESSAGE_INVALID_TYPE;
 import static seedu.clinic.testutil.TypicalSupplier.BOB;
 import static seedu.clinic.testutil.TypicalWarehouse.B;
 
@@ -64,37 +68,53 @@ public class AddCommandParserTest {
         Warehouse expectedWarehouse = new WarehouseBuilder(B).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
-                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_BOB, new AddCommand(expectedWarehouse));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + VALID_TYPE_SUPPLIER + NAME_DESC_BOB2
+                + PHONE_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
+                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
+                new AddCommand(expectedWarehouse));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY2 + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + EMAIL_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, NAME_DESC_WAREHOUSE_A2 + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
-                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B, new AddCommand(expectedWarehouse));
+        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_AMY2 + NAME_DESC_BOB2 + PHONE_DESC_BOB
+                + EMAIL_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + NAME_DESC_WAREHOUSE_B2
+                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
+                new AddCommand(expectedWarehouse));
 
         // multiple phones - last phone accepted
-        assertParseSuccess(parser, NAME_DESC_BOB2 + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_A + PHONE_DESC_WAREHOUSE_B
-                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B, new AddCommand(expectedWarehouse));
+        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_AMY + PHONE_DESC_BOB
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_A
+                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
+                new AddCommand(expectedWarehouse));
 
         // multiple emails - last email accepted
-        assertParseSuccess(parser, NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_AMY
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
 
         // multiple addresses - last email accepted
-        assertParseSuccess(parser, NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_A
-                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B, new AddCommand(expectedWarehouse));
+        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
+                + ADDRESS_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
+                new AddCommand(expectedWarehouse));
 
         // multiple remarks - last remark accepted
-        assertParseSuccess(parser, NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_AMY
-                + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, NAME_DESC_WAREHOUSE_B + PHONE_DESC_WAREHOUSE_B
+        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + REMARK_DESC_AMY + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B + PHONE_DESC_WAREHOUSE_B
                 + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
+
+        //all fields for suppliers
+        String userInputSupplier = " " + PREFIX_TYPE + "s " + NAME_DESC_BOB2 + PHONE_DESC_BOB
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB;
+        AddCommand expectedCommandSupplier = new AddCommand(expectedSupplier);
+        assertParseSuccess(parser, userInputSupplier, expectedCommandSupplier);
+
+        //all fields for warehouses
+        String userInputWarehouse = " " + PREFIX_TYPE + "w " + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
+                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B;
+        AddCommand expectedCommandWarehouse = new AddCommand(expectedWarehouse);
+        assertParseSuccess(parser, userInputWarehouse, expectedCommandWarehouse);
     }
 
     @Test
@@ -144,6 +164,14 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid type
+        assertParseFailure(parser, INVALID_TYPE_DESC + NAME_DESC_BOB2 + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                String.format(MESSAGE_INVALID_TYPE, AddCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, INVALID_TYPE_DESC + NAME_DESC_WAREHOUSE_A2
+                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                String.format(MESSAGE_INVALID_TYPE, AddCommand.MESSAGE_USAGE));
+
         // invalid name
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + INVALID_NAME_DESC2 + PHONE_DESC_BOB
                         + EMAIL_DESC_BOB + REMARK_DESC_BOB,
@@ -193,5 +221,9 @@ public class AddCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2
                         + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_WAREHOUSE_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
+
+        // empty input
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
@@ -39,7 +39,6 @@ import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_ADDRES
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_NAME_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PHONE_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_REMARK_A;
-import static seedu.clinic.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.clinic.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.clinic.logic.parser.ParserUtil.MESSAGE_INVALID_TYPE;
@@ -104,15 +103,15 @@ public class AddCommandParserTest {
                 + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
 
-        //all fields for suppliers
-        String userInputSupplier = " " + PREFIX_TYPE + "s " + NAME_DESC_BOB2 + PHONE_DESC_BOB
+        // all fields for suppliers
+        String userInputSupplier = " " + TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + REMARK_DESC_BOB;
         AddCommand expectedCommandSupplier = new AddCommand(expectedSupplier);
         assertParseSuccess(parser, userInputSupplier, expectedCommandSupplier);
 
-        //all fields for warehouses
-        String userInputWarehouse = " " + PREFIX_TYPE + "w " + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
-                + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B;
+        // all fields for warehouses
+        String userInputWarehouse = " " + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
+                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B;
         AddCommand expectedCommandWarehouse = new AddCommand(expectedWarehouse);
         assertParseSuccess(parser, userInputWarehouse, expectedCommandWarehouse);
     }

--- a/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
@@ -75,7 +75,7 @@ public class AddCommandParserTest {
 
         // multiple names - last name accepted
         assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_AMY2 + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
         assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + NAME_DESC_WAREHOUSE_B2
                 + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
@@ -91,7 +91,7 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_AMY
                 + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
 
-        // multiple addresses - last email accepted
+        // multiple addresses - last address accepted
         assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
                 + ADDRESS_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));

--- a/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/clinic/logic/parser/AddCommandParserTest.java
@@ -67,97 +67,92 @@ public class AddCommandParserTest {
         Warehouse expectedWarehouse = new WarehouseBuilder(B).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + VALID_TYPE_SUPPLIER + NAME_DESC_BOB2
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + TYPE_DESC_SUPPLIER + NAME_DESC_BOB2
                 + PHONE_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
+                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
+                new AddCommand(expectedWarehouse));
+
+        // multiple types - last type accepted
+        assertParseSuccess(parser, TYPE_DESC_WAREHOUSE + TYPE_DESC_SUPPLIER + NAME_DESC_BOB2
+                + PHONE_DESC_BOB + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
+        assertParseSuccess(parser, TYPE_DESC_SUPPLIER + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
                 + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_AMY2 + NAME_DESC_BOB2 + PHONE_DESC_BOB
+        assertParseSuccess(parser, TYPE_DESC_SUPPLIER + NAME_DESC_AMY2 + NAME_DESC_BOB2 + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + NAME_DESC_WAREHOUSE_B2
+        assertParseSuccess(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + NAME_DESC_WAREHOUSE_B2
                 + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
 
         // multiple phones - last phone accepted
-        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_AMY + PHONE_DESC_BOB
+        assertParseSuccess(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_AMY + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_A
+        assertParseSuccess(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_A
                 + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
 
         // multiple emails - last email accepted
-        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_AMY
+        assertParseSuccess(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_AMY
                 + EMAIL_DESC_BOB + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
 
         // multiple addresses - last address accepted
-        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
+        assertParseSuccess(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2 + PHONE_DESC_WAREHOUSE_B
                 + ADDRESS_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
 
         // multiple remarks - last remark accepted
-        assertParseSuccess(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        assertParseSuccess(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + REMARK_DESC_AMY + REMARK_DESC_BOB, new AddCommand(expectedSupplier));
-        assertParseSuccess(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_B + PHONE_DESC_WAREHOUSE_B
+        assertParseSuccess(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B + PHONE_DESC_WAREHOUSE_B
                 + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_B,
                 new AddCommand(expectedWarehouse));
-
-        // all fields for suppliers
-        String userInputSupplier = " " + TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + REMARK_DESC_BOB;
-        AddCommand expectedCommandSupplier = new AddCommand(expectedSupplier);
-        assertParseSuccess(parser, userInputSupplier, expectedCommandSupplier);
-
-        // all fields for warehouses
-        String userInputWarehouse = " " + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_B2
-                + PHONE_DESC_WAREHOUSE_B + ADDRESS_DESC_WAREHOUSE_B + REMARK_DESC_WAREHOUSE_B;
-        AddCommand expectedCommandWarehouse = new AddCommand(expectedWarehouse);
-        assertParseSuccess(parser, userInputWarehouse, expectedCommandWarehouse);
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         // missing type prefix
         assertParseFailure(parser, VALID_TYPE_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 String.format(AddCommand.MESSAGE_MISSING_TYPE_PREFIX, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, VALID_TYPE_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + PHONE_DESC_WAREHOUSE_A
-                        + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_MISSING_TYPE_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // missing name prefix
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + PHONE_DESC_BOB + VALID_NAME_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 String.format(AddCommand.MESSAGE_SUPPLIER_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + PHONE_DESC_WAREHOUSE_A + VALID_WAREHOUSE_NAME_A
-                        + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_WAREHOUSE_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // missing phone prefix
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + VALID_PHONE_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 String.format(AddCommand.MESSAGE_SUPPLIER_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + VALID_WAREHOUSE_PHONE_A
-                        + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_WAREHOUSE_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // missing email prefix
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + VALID_EMAIL_BOB + REMARK_DESC_BOB,
+                + VALID_EMAIL_BOB + REMARK_DESC_BOB,
                 String.format(AddCommand.MESSAGE_SUPPLIER_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // missing address prefix
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2 + PHONE_DESC_WAREHOUSE_A
-                        + VALID_WAREHOUSE_ADDRESS_A + REMARK_DESC_WAREHOUSE_A,
+                + VALID_WAREHOUSE_ADDRESS_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_WAREHOUSE_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // all prefixes missing
         assertParseFailure(parser, VALID_TYPE_SUPPLIER + VALID_NAME_BOB + VALID_PHONE_BOB
-                        + VALID_EMAIL_BOB + VALID_REMARK_BOB,
+                + VALID_EMAIL_BOB + VALID_REMARK_BOB,
                 String.format(AddCommand.MESSAGE_MISSING_TYPE_PREFIX, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, VALID_TYPE_WAREHOUSE + VALID_WAREHOUSE_NAME_A + VALID_WAREHOUSE_PHONE_A
-                        + VALID_WAREHOUSE_ADDRESS_A + VALID_WAREHOUSE_REMARK_A,
+                + VALID_WAREHOUSE_ADDRESS_A + VALID_WAREHOUSE_REMARK_A,
                 String.format(AddCommand.MESSAGE_MISSING_TYPE_PREFIX, AddCommand.MESSAGE_USAGE));
     }
 
@@ -165,60 +160,60 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid type
         assertParseFailure(parser, INVALID_TYPE_DESC + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 String.format(MESSAGE_INVALID_TYPE, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, INVALID_TYPE_DESC + NAME_DESC_WAREHOUSE_A2
-                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(MESSAGE_INVALID_TYPE, AddCommand.MESSAGE_USAGE));
 
         // invalid name
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + INVALID_NAME_DESC2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + INVALID_NAME_DESC_WAREHOUSE2
-                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + INVALID_PHONE_DESC
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 Phone.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2
-                        + INVALID_PHONE_DESC + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + INVALID_PHONE_DESC + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + INVALID_EMAIL_DESC + REMARK_DESC_BOB,
+                + INVALID_EMAIL_DESC + REMARK_DESC_BOB,
                 Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2
-                        + PHONE_DESC_WAREHOUSE_A + INVALID_ADDRESS_DESC + REMARK_DESC_WAREHOUSE_A,
+                + PHONE_DESC_WAREHOUSE_A + INVALID_ADDRESS_DESC + REMARK_DESC_WAREHOUSE_A,
                 Address.MESSAGE_CONSTRAINTS);
 
         // invalid remark
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + INVALID_REMARK_DESC,
+                + EMAIL_DESC_BOB + INVALID_REMARK_DESC,
                 Remark.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2
-                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + INVALID_REMARK_DESC,
+                + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + INVALID_REMARK_DESC,
                 Remark.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, TYPE_DESC_SUPPLIER + INVALID_NAME_DESC2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + INVALID_REMARK_DESC,
+                + EMAIL_DESC_BOB + INVALID_REMARK_DESC,
                 Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, TYPE_DESC_WAREHOUSE + INVALID_NAME_DESC_WAREHOUSE2
-                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + INVALID_REMARK_DESC,
+                + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + INVALID_REMARK_DESC,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TYPE_DESC_SUPPLIER + NAME_DESC_BOB2 + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + REMARK_DESC_BOB,
+                + EMAIL_DESC_BOB + REMARK_DESC_BOB,
                 String.format(AddCommand.MESSAGE_SUPPLIER_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TYPE_DESC_WAREHOUSE + NAME_DESC_WAREHOUSE_A2
-                        + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
+                + PHONE_DESC_WAREHOUSE_A + ADDRESS_DESC_WAREHOUSE_A + REMARK_DESC_WAREHOUSE_A,
                 String.format(AddCommand.MESSAGE_WAREHOUSE_MISSING_PREFIX, AddCommand.MESSAGE_USAGE));
 
         // empty input

--- a/src/test/java/seedu/clinic/model/warehouse/WarehouseTest.java
+++ b/src/test/java/seedu/clinic/model/warehouse/WarehouseTest.java
@@ -6,7 +6,9 @@ import static seedu.clinic.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_ADDRESS_B;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_NAME_B;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PHONE_B;
+import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_NAME_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_NAME_B;
+import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_QUANTITY_A;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_PRODUCT_QUANTITY_B;
 import static seedu.clinic.logic.commands.CommandTestUtil.VALID_WAREHOUSE_REMARK_B;
 import static seedu.clinic.testutil.Assert.assertThrows;
@@ -63,7 +65,8 @@ class WarehouseTest {
     @Test
     public void equals() {
         // same values -> returns true
-        Warehouse aCopy = new WarehouseBuilder(A).build();
+        Warehouse aCopy = new WarehouseBuilder(A)
+                .withProducts(Map.of(VALID_WAREHOUSE_PRODUCT_NAME_A, VALID_WAREHOUSE_PRODUCT_QUANTITY_A)).build();
         assertTrue(A.equals(aCopy));
 
         // same object -> returns true

--- a/src/test/java/seedu/clinic/testutil/WarehouseBuilder.java
+++ b/src/test/java/seedu/clinic/testutil/WarehouseBuilder.java
@@ -46,7 +46,7 @@ public class WarehouseBuilder {
         phone = warehouseToCopy.getPhone();
         address = warehouseToCopy.getAddress();
         remark = warehouseToCopy.getRemark();
-        products = new HashSet<>(warehouseToCopy.getProducts());
+        products = new HashSet<>();
     }
 
     /**


### PR DESCRIPTION
Line coverage for AddCommand and AddCommandParser increased to 100%.

While writing test cases, I found WarehouseBuilder not initialising warehouses with empty set for product which is not aligned with the initial addition of warehouses. I have made the changes in the affected tests, namely WarehouseTest and EditCommandTest by including the products using the withProducts() method. 