### PR TITLE
Fix bugs for AutoComplete

### DIFF
--- a/src/main/java/seedu/clinic/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/UpdateCommand.java
@@ -36,8 +36,8 @@ import seedu.clinic.model.warehouse.Warehouse;
 public class UpdateCommand extends Command {
 
     public static final String COMMAND_WORD = "update";
-    public static final String COMPULSORY_UPDATE_SUPPLIER_COMMAND = "update ct/s n/ pd/";
-    public static final String COMPULSORY_UPDATE_WAREHOUSE_COMMAND = "update ct/w n/ pd/";
+    public static final String COMPULSORY_UPDATE_SUPPLIER_COMMAND = "update ct/s i/ pd/";
+    public static final String COMPULSORY_UPDATE_WAREHOUSE_COMMAND = "update ct/w i/ pd/";
 
     public static final String MESSAGE_USAGE = "Update Command Usage\n\nUpdates the quantity and/or tags of"
             + " the product with the specified"

--- a/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/clinic/logic/commands/ViewCommand.java
@@ -38,6 +38,9 @@ public class ViewCommand extends Command {
             + "1) " + COMMAND_WORD + " " + PREFIX_TYPE + "s " + PREFIX_INDEX + "2\n"
             + "2) " + COMMAND_WORD + " " + PREFIX_TYPE + "w " + PREFIX_INDEX + "5";
 
+    public static final String COMPULSORY_VIEW_SUPPLIER_COMMAND = "view ct/s i/";
+    public static final String COMPULSORY_VIEW_WAREHOUSE_COMMAND = "view ct/w i/";
+
     public static final String MESSAGE_INVALID_TYPE_VIEW = "Please specify a correct type,"
             + " either ct/s or ct/w\n%1$s";
 

--- a/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
+++ b/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
@@ -33,7 +33,7 @@ import seedu.clinic.logic.commands.ViewCommand;
  */
 public class AutoCompleteTextField extends TextField {
     private static final SortedSet<String> entries = new TreeSet<>();
-    private static final SortedSet<String> allowedEntries = new TreeSet<>();
+    private static final SortedSet<String> singleCommandEntries = new TreeSet<>();
     private ContextMenu popUpEntries;
 
     /**
@@ -63,7 +63,7 @@ public class AutoCompleteTextField extends TextField {
     private void checkPopUpEntries() {
         System.out.println(getText());
         if (!popUpEntries.isShowing()) {
-            if (!getText().equals("list") && !allowedEntries.contains(getText())) {
+            if (getText().equals("list") && !singleCommandEntries.contains(getText())) {
                 popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
             }
         }
@@ -73,14 +73,14 @@ public class AutoCompleteTextField extends TextField {
      * Create the existing set of autocomplete entries with single command word.
      */
     private void setSingleCommandEntries() {
-        allowedEntries.add(ClearCommand.COMMAND_WORD);
-        allowedEntries.add(ExitCommand.COMMAND_WORD);
-        allowedEntries.add(ListCommand.COMMAND_WORD);
-        allowedEntries.add(ListMacroCommand.COMMAND_WORD);
-        allowedEntries.add(HelpCommand.COMMAND_WORD);
-        allowedEntries.add(RedoCommand.COMMAND_WORD);
-        allowedEntries.add(RemoveMacroCommand.COMPLETE_REMOVE_MACRO_COMMAND);
-        allowedEntries.add(UndoCommand.COMMAND_WORD);
+        singleCommandEntries.add(ClearCommand.COMMAND_WORD);
+        singleCommandEntries.add(ExitCommand.COMMAND_WORD);
+        singleCommandEntries.add(ListCommand.COMMAND_WORD);
+        singleCommandEntries.add(ListMacroCommand.COMMAND_WORD);
+        singleCommandEntries.add(HelpCommand.COMMAND_WORD);
+        singleCommandEntries.add(RedoCommand.COMMAND_WORD);
+        singleCommandEntries.add(RemoveMacroCommand.COMPLETE_REMOVE_MACRO_COMMAND);
+        singleCommandEntries.add(UndoCommand.COMMAND_WORD);
     }
 
     /**

--- a/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
+++ b/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
@@ -33,6 +33,7 @@ import seedu.clinic.logic.commands.ViewCommand;
  */
 public class AutoCompleteTextField extends TextField {
     private static final SortedSet<String> entries = new TreeSet<>();
+    private static final SortedSet<String> allowedEntries = new TreeSet<>();
     private ContextMenu popUpEntries;
 
     /**
@@ -41,6 +42,7 @@ public class AutoCompleteTextField extends TextField {
     public AutoCompleteTextField() {
         super();
         this.setEntries();
+        this.setSingleCommandEntries();
         popUpEntries = new ContextMenu();
         textProperty().addListener((observableValue, s, s2) -> {
             if (getText().length() == 0) {
@@ -51,13 +53,29 @@ public class AutoCompleteTextField extends TextField {
                 searchResult.addAll(entries.subSet(getText(), getText() + Character.MAX_VALUE));
                 populatePopup(searchResult);
                 if (!popUpEntries.isShowing()) {
-                    popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
+                    if (!getText().equals("list") && !allowedEntries.contains(getText())) {
+                        popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
+                    }
                 }
             }
         });
 
         focusedProperty().addListener((observableValue, aBoolean, aBoolean2) ->
                 popUpEntries.hide());
+    }
+
+    /**
+     * Create the existing set of autocomplete entries with single command word.
+     */
+    private void setSingleCommandEntries() {
+        allowedEntries.add(ClearCommand.COMMAND_WORD);
+        allowedEntries.add(ExitCommand.COMMAND_WORD);
+        allowedEntries.add(ListCommand.COMMAND_WORD);
+        allowedEntries.add(ListMacroCommand.COMMAND_WORD);
+        allowedEntries.add(HelpCommand.COMMAND_WORD);
+        allowedEntries.add(RedoCommand.COMMAND_WORD);
+        allowedEntries.add(RemoveMacroCommand.COMPLETE_REMOVE_MACRO_COMMAND);
+        allowedEntries.add(UndoCommand.COMMAND_WORD);
     }
 
     /**
@@ -85,8 +103,11 @@ public class AutoCompleteTextField extends TextField {
         entries.add(UndoCommand.COMMAND_WORD);
         entries.add(UpdateCommand.COMPULSORY_UPDATE_SUPPLIER_COMMAND);
         entries.add(UpdateCommand.COMPULSORY_UPDATE_WAREHOUSE_COMMAND);
-        entries.add(ViewCommand.COMMAND_WORD);
+        entries.add(ViewCommand.COMPULSORY_VIEW_SUPPLIER_COMMAND);
+        entries.add(ViewCommand.COMPULSORY_VIEW_WAREHOUSE_COMMAND);
     }
+
+
 
     /**
      * Populate the entry set matching the user input.

--- a/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
+++ b/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
@@ -52,16 +52,21 @@ public class AutoCompleteTextField extends TextField {
                 LinkedList<String> searchResult = new LinkedList<>();
                 searchResult.addAll(entries.subSet(getText(), getText() + Character.MAX_VALUE));
                 populatePopup(searchResult);
-                if (!popUpEntries.isShowing()) {
-                    if (!getText().equals("list") && !allowedEntries.contains(getText())) {
-                        popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
-                    }
-                }
+                checkPopUpEntries();
             }
         });
 
         focusedProperty().addListener((observableValue, aBoolean, aBoolean2) ->
                 popUpEntries.hide());
+    }
+
+    private void checkPopUpEntries() {
+        System.out.println(getText());
+        if (!popUpEntries.isShowing()) {
+            if (!getText().equals("list") && !allowedEntries.contains(getText())) {
+                popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
+            }
+        }
     }
 
     /**

--- a/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
+++ b/src/main/java/seedu/clinic/ui/AutoCompleteTextField.java
@@ -63,7 +63,7 @@ public class AutoCompleteTextField extends TextField {
     private void checkPopUpEntries() {
         System.out.println(getText());
         if (!popUpEntries.isShowing()) {
-            if (getText().equals("list") && !singleCommandEntries.contains(getText())) {
+            if (!getText().equals("list") && !singleCommandEntries.contains(getText())) {
                 popUpEntries.show(AutoCompleteTextField.this, Side.BOTTOM, 15, -180);
             }
         }


### PR DESCRIPTION
- [x] Fixed single command prompt showing up when trying to view history commands
- [x] Updated autocomplete texts for view and update command
- [ ] A little bug when going up to view history, sometimes up arrow keys has to be pressed twice
- [x] Once user has typed `list` in full, `listmacro` will not be suggested as autocomplete to resolve the one-worded command prompts showing up when going through commandHistory.